### PR TITLE
Shortened URL length to 75 and fixed screen flickering

### DIFF
--- a/datanar/datanar/settings.py
+++ b/datanar/datanar/settings.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext_lazy as _
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-VERSION = "1.5.7"
+VERSION = "1.5.8"
 
 SECRET_KEY = config(
     "DJANGO_SECRET_KEY",

--- a/datanar/redirects/admin.py
+++ b/datanar/redirects/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.translation import gettext_lazy as _
 
 from redirects import models as redirects_models
 from statistic import models as statistic_models
@@ -20,9 +21,18 @@ class ClickInline(admin.TabularInline):
 @admin.register(redirects_models.Redirect)
 class ItemAdmin(admin.ModelAdmin):
     list_display = (
-        redirects_models.Redirect.long_link.field.name,
+        "view_long_link",
         redirects_models.Redirect.short_link.field.name,
+        redirects_models.Redirect.created_at.field.name,
     )
+
+    @admin.display(
+        description=_("long_link"),
+    )
+    def view_long_link(self, obj):
+        if obj.long_link and len(obj.long_link) > 75:
+            return obj.long_link[:75] + "..."
+        return obj.long_link
 
     inlines = [
         ClickInline,

--- a/datanar/templates/base.html
+++ b/datanar/templates/base.html
@@ -11,7 +11,6 @@
 
     <title>{% block title %}{% endblock %}</title>
 
-    <script src="{% static 'js/bootstrap.bundle.min.js' %}"></script>
     <script src="{% static 'js/colorTogler.js' %}"></script>
 
     <link rel="icon" type="image/ico" href="{% static 'img/favicon.ico' %}">
@@ -31,6 +30,7 @@
       {% endblock %}
     </main>
     {% include "includes/footer.html" %}
+    <script src="{% static 'js/bootstrap.bundle.min.js' %}"></script>
     {% block js %}
 
     {% endblock %}

--- a/datanar/templates/base.html
+++ b/datanar/templates/base.html
@@ -13,9 +13,6 @@
 
     <script src="{% static 'js/bootstrap.bundle.min.js' %}"></script>
     <script src="{% static 'js/colorTogler.js' %}"></script>
-    {% block js %}
-
-    {% endblock %}
 
     <link rel="icon" type="image/ico" href="{% static 'img/favicon.ico' %}">
     <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
@@ -34,6 +31,8 @@
       {% endblock %}
     </main>
     {% include "includes/footer.html" %}
+    {% block js %}
 
+    {% endblock %}
   </body>
 </html>

--- a/datanar/templates/base.html
+++ b/datanar/templates/base.html
@@ -4,12 +4,18 @@
 
 <!DOCTYPE html>
 
-<html lang="ru">
+<html lang="ru" data-bs-theme="auto">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <title>{% block title %}{% endblock %}</title>
+
+    <script src="{% static 'js/bootstrap.bundle.min.js' %}"></script>
+    <script src="{% static 'js/colorTogler.js' %}"></script>
+    {% block js %}
+
+    {% endblock %}
 
     <link rel="icon" type="image/ico" href="{% static 'img/favicon.ico' %}">
     <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
@@ -29,10 +35,5 @@
     </main>
     {% include "includes/footer.html" %}
 
-    <script src="{% static 'js/bootstrap.bundle.min.js' %}"></script>
-    <script src="{% static 'js/colorTogler.js' %}"></script>
-    {% block js %}
-
-    {% endblock %}
   </body>
 </html>


### PR DESCRIPTION
- Сократил длину ссылки до 75 символов при отображении в админке и добавил отображение времени создания
![изображение](https://github.com/Gray-Advantage/Datanar-Django/assets/68778953/9620cd73-653b-417c-91a0-2c253e188340)
- Исправил мерцание экрана при загрузке страницы если включена темная тема